### PR TITLE
MIT license to the repo

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,18 @@
+Copyright 2024 Murhaf Shaker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## What?

This PR adds an [MIT license](https://opensource.org/license/mit) to this repository.

## How?

I used the current year and your name to fill out the `<YEAR>` and `<COPYRIGHT HOLDER>` sections of the MIT license, respectively.

## Why?

In general, it is a good idea to always add a license to an open source project so that other people and organizations can use your work without fear of the legal risk associated with making changes and distributing changes. The best and most recent example I can think of is the [dust DS emulator from the Rust ecosystem](https://www.reddit.com/r/rust/comments/14lamyg/please_add_licenses_to_your_projects_rust_ds/). This repository did not have a license associated with it, and so when it was unexpectedly deleted, none of the existing forks could be used to continue development.

I'm just an individual, not a corporation, but I always feel better using software that has been explicitly licensed.

---

Thank you for putting together such a great theme! Planning to use this color palette to style my whole desktop environment :)

Cheers,
- Nick